### PR TITLE
Update train.py

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -23,7 +23,7 @@ def history_to_csv(history):
 
 def main():
     params = load_params()
-    m = model.get_model()
+    m = models.get_model()
     m.summary()
 
     whole_train_img, whole_train_labels = load_npz_data("data/preprocessed/mnist-train.npz")


### PR DESCRIPTION
fix error with module name misspelled. Found this when running this tutorial on Katakoda.

Another error with that tutorial: `dvc pull` is not done after the environment starts, so the first step fails with an error:
```
~/example-get-started$ dvc exp run --set-param model.name=mlp
Verifying outputs in frozen stage: 'data/raw.dvc'                                                                                          
ERROR: failed to reproduce 'data/raw.dvc': missing data 'source': data/raw
```

though it is not hard to figure it out, it would be great to fix this. Didn't find a way to fix this in the repo, so this is probably should be done somewhere else :)